### PR TITLE
Fix isInteractiveMessageReply() always true

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -108,7 +108,7 @@ class WebDriver extends HttpDriver
     {
         $interactive = $this->event->get('interactive', false);
         if (is_string($interactive)) {
-            $interactive = $interactive !== 'false';
+            $interactive = ($interactive !== 'false') && ($interactive !== '0');
         } else {
             $interactive = (bool) $interactive;
         }


### PR DESCRIPTION
The web widget passes the interactive parameter as 0 and 1 and currently isInteractiveMessageReply() always returns true. The proposed change fixes the issue.