### PR TITLE
Added in empty catch for json_decode

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -51,6 +51,9 @@ class WebDriver extends HttpDriver
     public function buildPayload(Request $request)
     {
         $this->payload = $request->request->all();
+        if(!empty($request->getContent()) && empty($this->payload)){
+            $this->payload = json_decode($request->getContent(), true);
+        }
         $this->event = Collection::make($this->payload);
         $this->files = Collection::make($request->files->all());
         $this->config = Collection::make($this->config->get('web', []));


### PR DESCRIPTION
Lumen and possible other setups are not having their JSON content decoded in the Symfony request. This is an attempt to capture any missed content from Symfony's `request->all()` method and prepare it for Botman to carry on delivering the response